### PR TITLE
fix(test): add mock for CSS styles

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,14 +10,14 @@ module.exports = {
   // The directory where Jest should output its coverage files
   coverageDirectory: 'coverage',
 
-  transform: {
-    '\\.(ts|tsx)$': 'ts-jest',
+  moduleNameMapper: {
+    '\\.(css|less)$': path.resolve(__dirname, './src/__mocks__/styleMock.js'),
   },
-
-  roots: ['<rootDir>'],
 
   // A preset that is used as a base for Jest's configuration
   preset: 'ts-jest',
+
+  roots: ['<rootDir>'],
 
   // The path to a module that runs some code to configure or set up the testing framework before each test
   setupFilesAfterEnv: [path.resolve(__dirname, 'src', './setupTests.ts')],
@@ -25,4 +25,8 @@ module.exports = {
   testEnvironment: 'jsdom',
 
   testMatch:["<rootDir>/src/*.test.{js,jsx,ts,tsx}"],
+
+  transform: {
+    '\\.(ts|tsx)$': 'ts-jest',
+  },
 };

--- a/src/__mocks__/styleMock.js
+++ b/src/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,2 +1,1 @@
-// @ts-ignore
 import('./bootstrap');


### PR DESCRIPTION
This fixes the issue where tests fail if they import a component that uses PatternFly components with CSS from `@patternfly/patternfly-react` and `@patternfly/patternfly-styles/css`.

## Changes
- Add mock for CSS/LESS styles
- Point to mock from `moduleNameMapper` in `jest.config.js`

I also ABC ordered the `jest.config.js` options, sorry. 😄 