### PR TITLE
fix(ci): enable webpack xxhash64 hash function

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,7 @@ module.exports = {
     port: 3002,
   },
   output: {
+    hashFunction: 'xxhash64',
     publicPath: "auto",
   },
   module: {


### PR DESCRIPTION
## Purpose
Fixes an issue seen in [step-extension-repository](https://github.com/KaotoIO/step-extension-repository/pull/74) where the build passes but step extensions are not published to GH pages and cannot be loaded. This issue will likely occur in this repo as well once we are supporting a later version of Node, as we should be soon.

The following error is observed in the build logs:

```
$ webpack --mode production --config webpack.common.js
Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at BulkUpdateDecorator.hashFactory (/home/runner/work/step-extension-repository/step-extension-repository/set-property/node_modules/webpack/lib/util/createHash.js:145:18)
    at BulkUpdateDecorator.update (/home/runner/work/step-extension-repository/step-extension-repository/set-property/node_modules/webpack/lib/util/createHash.js:46:50)
    at OriginalSource.updateHash (/home/runner/work/step-extension-repository/step-extension-repository/set-property/node_modules/webpack/node_modules/webpack-sources/lib/OriginalSource.js:130:8)
    at NormalModule._initBuildHash (/home/runner/work/step-extension-repository/step-extension-repository/set-property/node_modules/webpack/lib/NormalModule.js:888:17)
    at handleParseResult (/home/runner/work/step-extension-repository/step-extension-repository/set-property/node_modules/webpack/lib/NormalModule.js:954:10)
    at /home/runner/work/step-extension-repository/step-extension-repository/set-property/node_modules/webpack/lib/NormalModule.js:1048:4
    at processResult (/home/runner/work/step-extension-repository/step-extension-repository/set-property/node_modules/webpack/lib/NormalModule.js:763:11)
    at /home/runner/work/step-extension-repository/step-extension-repository/set-property/node_modules/webpack/lib/NormalModule.js:827:5
node:internal/crypto/hash:71
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^
```